### PR TITLE
PLUTO-683 - TCK: Contesting tests that invoke a ResourceURL that

### DIFF
--- a/portlet-tck_3.0/V2AddlRequestTests/src/main/webapp/WEB-INF/liferay-portlet.xml
+++ b/portlet-tck_3.0/V2AddlRequestTests/src/main/webapp/WEB-INF/liferay-portlet.xml
@@ -5,7 +5,7 @@
 	<portlet>
 		<portlet-name>AddlRequestTests_SPEC2_11_Action</portlet-name>
 		<friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>
-		<friendly-url-mapping>portlet-tck</friendly-url-mapping>
+		<friendly-url-mapping>AddlRequestTests-friendly</friendly-url-mapping>
 		<friendly-url-routes>friendly-url-routes.xml</friendly-url-routes>
 		<requires-namespaced-parameters>false</requires-namespaced-parameters>
 	</portlet>

--- a/portlet-tck_3.0/V2URLTests/src/main/resources/friendly-url-routes.xml
+++ b/portlet-tck_3.0/V2URLTests/src/main/resources/friendly-url-routes.xml
@@ -1,0 +1,9 @@
+
+<?xml version="1.0"?>
+<!DOCTYPE routes PUBLIC "-//Liferay//DTD Friendly URL Routes 7.0.0//EN" "http://www.liferay.com/dtd/liferay-friendly-url-routes_7_0_0.dtd">
+
+<routes>
+	<route>
+		<pattern>/{p_p_lifecycle}/{p_p_state}/{p_p_mode}/{p_p_cacheability}</pattern>
+	</route>
+</routes>

--- a/portlet-tck_3.0/V2URLTests/src/main/webapp/WEB-INF/liferay-portlet.xml
+++ b/portlet-tck_3.0/V2URLTests/src/main/webapp/WEB-INF/liferay-portlet.xml
@@ -12,6 +12,10 @@
 	</portlet>
 	<portlet>
 		<portlet-name>URLTests_BaseURL_ApiRenderResurl</portlet-name>
+		<friendly-url-mapper-class>com.liferay.portal.kernel.portlet.DefaultFriendlyURLMapper</friendly-url-mapper-class>
+		<friendly-url-mapping>URLTests-friendly</friendly-url-mapping>
+		<friendly-url-routes>friendly-url-routes.xml</friendly-url-routes>
+		<instanceable>false</instanceable>
 		<requires-namespaced-parameters>false</requires-namespaced-parameters>
 	</portlet>
 	<portlet>


### PR DESCRIPTION
was written to the response with BaseURL.write(Writer writer, boolean escapeXML) when passing escapeXML=true